### PR TITLE
Implements C level interface

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # sakura (development version)
 
-* Implements a C level interface through `sakura_serialize()` and `sakura_unserialize()`.
+* Implements a C level interface with public declarations in `sakura.h`.
 
 # sakura 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # sakura (development version)
 
+* Implements a C level interface through `sakura_serialize()` and `sakura_unserialize()`.
+
 # sakura 0.1.0
 
 * Initial CRAN release.

--- a/R/sakura.R
+++ b/R/sakura.R
@@ -57,12 +57,12 @@
 #'
 #' @export
 #'
-serialize <- function(x, hook = NULL) .Call(sakura_serialize, x, hook)
+serialize <- function(x, hook = NULL) .Call(sakura_r_serialize, x, hook)
 
 #' @rdname serialize
 #' @export
 #'
-unserialize <- function(x, hook = NULL) .Call(sakura_unserialize, x, hook)
+unserialize <- function(x, hook = NULL) .Call(sakura_r_unserialize, x, hook)
 
 #' Create Serialization Configuration
 #'

--- a/inst/include/sakura.h
+++ b/inst/include/sakura.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Hibiki AI Limited <info@hibiki-ai.com>
+//
+// This file is part of sakura.
+//
+// sakura is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// sakura is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// sakura. If not, see <https://www.gnu.org/licenses/>.
+
+// sakura - public header file -------------------------------------------------
+
+#ifndef SAKURA_H
+#define SAKURA_H
+
+#include <R.h>
+#include <Rinternals.h>
+
+typedef struct nano_buf_s {
+  unsigned char *buf;
+  size_t len;
+  size_t cur;
+} nano_buf;
+
+typedef void (*sakura_sfunc)(nano_buf *, SEXP, SEXP);
+typedef SEXP (*sakura_ufunc)(unsigned char *, size_t, SEXP);
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -19,8 +19,8 @@
 #include "sakura.h"
 
 static const R_CallMethodDef callMethods[] = {
-  {"sakura_serialize", (DL_FUNC) &sakura_serialize, 2},
-  {"sakura_unserialize", (DL_FUNC) &sakura_unserialize, 2},
+  {"sakura_r_serialize", (DL_FUNC) &sakura_r_serialize, 2},
+  {"sakura_r_unserialize", (DL_FUNC) &sakura_r_unserialize, 2},
   {NULL, NULL, 0}
 };
 
@@ -28,4 +28,6 @@ void attribute_visible R_init_sakura(DllInfo* dll) {
   R_registerRoutines(dll, NULL, callMethods, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
   R_forceSymbols(dll, TRUE);
+  R_RegisterCCallable("sakura", "sakura_serialize", (DL_FUNC) &sakura_serialize);
+  R_RegisterCCallable("sakura", "sakura_unserialize", (DL_FUNC) &sakura_unserialize);
 }

--- a/src/sakura.h
+++ b/src/sakura.h
@@ -41,7 +41,10 @@ typedef struct nano_buf_s {
 #define SAKURA_SERIAL_THR 134217728
 #define SAKURA_LD_STRLEN 21
 
-SEXP sakura_serialize(SEXP, SEXP);
-SEXP sakura_unserialize(SEXP, SEXP);
+void sakura_serialize(nano_buf *, SEXP, SEXP);
+SEXP sakura_unserialize(unsigned char *, size_t, SEXP);
+
+SEXP sakura_r_serialize(SEXP, SEXP);
+SEXP sakura_r_unserialize(SEXP, SEXP);
 
 #endif


### PR DESCRIPTION
As per https://github.com/RConsortium/marshalling-wg/issues/7#issuecomment-2694352279, this PR implements an interface at the C level.

Registers C callables with the following function signatures:

```c
void sakura_serialize(nano_buf *, SEXP, SEXP);
SEXP sakura_unserialize(unsigned char *, size_t, SEXP);
```
where a `nano_buf` is defined:
```c
typedef struct nano_buf_s {
  unsigned char *buf;
  size_t len;
  size_t cur;
} nano_buf;
```