### PR TITLE
Use system endianness for serialize()

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -141,11 +141,7 @@ void sakura_serialize_init(SEXP bundle_xptr, R_outpstream_t stream, R_pstream_da
   R_InitOutPStream(
     stream,
     data,
-#ifdef WORDS_BIGENDIAN
-    R_pstream_xdr_format,
-#else
     R_pstream_binary_format,
-#endif
     SAKURA_SERIAL_VER,
     NULL,
     outbytes,
@@ -188,11 +184,7 @@ void sakura_serialize(nano_buf *buf, SEXP object, SEXP hook) {
     R_InitOutPStream(
       &output_stream,
       (R_pstream_data_t) buf,
-#ifdef WORDS_BIGENDIAN
-      R_pstream_xdr_format,
-#else
       R_pstream_binary_format,
-#endif
       SAKURA_SERIAL_VER,
       NULL,
       nano_write_bytes,


### PR DESCRIPTION
As follow up to #8.

@traversc I believe this PR doesn't actually result in any change in behaviour except for stripping out some unnecessary code, but just to confirm my intention is to use system endianness, which should be sufficient for marshalling requirements in almost all situations.

We may want to ensure a consistent endianness for the rare occasions you want to connect from a little to big endian machine, or for archival purposes - but I'll leave that for another time.