### PR TITLE
Allows multiple serial configs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # sakura (development version)
 
+* `serial_config()` can now be used to specify multiple custom serialization functions for different classes of object (#12).
 * Updates the internal mechanism to use inline serialization (@traversc and @shikokuchuo, #8).
 * `serial_config()` is simplified by removing the `vec` argument, as this is no longer relevant after the adoption of inline serialization.
 * Implements a C level interface with public declarations in `inst/include/sakura.h`.

--- a/R/sakura.R
+++ b/R/sakura.R
@@ -40,16 +40,17 @@
 #' raw <- serialize(obj, cfg)
 #' unserialize(raw, cfg)
 #'
-#' @export
-#'
-serialize <- function(x, hook = NULL)
-  .Call(sakura_r_serialize, x, hook)
-
 #' @examplesIf requireNamespace("torch", quietly = TRUE)
 #' x <- list(torch::torch_rand(5L), runif(5L))
 #' cfg <- serial_config("torch_tensor", torch::torch_serialize, torch::torch_load)
 #' unserialize(serialize(x, cfg), cfg)
 #'
+#' @export
+#'
+serialize <- function(x, hook = NULL)
+  .Call(sakura_r_serialize, x, hook)
+
+#' @examplesIf requireNamespace("arrow", quietly = TRUE) && requireNamespace("torch", quietly = TRUE)
 #' cfg <- serial_config(
 #'   c("torch_tensor", "ArrowTabular"),
 #'   list(torch::torch_serialize, arrow::write_to_raw),
@@ -70,22 +71,24 @@ unserialize <- function(x, hook = NULL)
 #' unserialization of non-system reference objects, using the 'refhook' system
 #' of R native serialization. This allows their use across different R sessions.
 #'
-#' @param class character string of the class of object custom serialization
-#'   functions are applied to, e.g. 'ArrowTabular' or 'torch_tensor'.
-#' @param sfunc a function that accepts a reference object inheriting from
-#'   `class` and returns a raw vector.
-#' @param ufunc a function that accepts a raw vector and returns a reference
-#'   object.
+#' @param class a character string (or vector) of the class of object custom
+#'   serialization functions are applied to, e.g. `'ArrowTabular'` or
+#'   `c('torch_tensor', 'ArrowTabular')`.
+#' @param sfunc a function (or list of functions) that accepts a reference
+#'   object inheriting from `class` and returns a raw vector.
+#' @param ufunc a function (or list of functions) that accepts a raw vector and
+#'   returns a reference object.
 #'
 #' @return A pairlist comprising the configuration. This may be provided to the
 #'   `hook` argument of [serialize()] and [unserialize()].
 #'
 #' @examples
 #' serial_config("test_class", base::serialize, base::unserialize)
+#'
 #' serial_config(
-#'   c("torch_tensor", "ArrowTabular"),
-#'   list(torch::torch_serialize, arrow::write_to_raw),
-#'   list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+#'   c("class_one", "class_two"),
+#'   list(base::serialize, base::serialize),
+#'   list(base::unserialize, base::unserialize)
 #' )
 #'
 #' @export

--- a/R/sakura.R
+++ b/R/sakura.R
@@ -74,15 +74,25 @@ unserialize <- function(x, hook = NULL)
 #'
 #' @examples
 #' serial_config("test_class", base::serialize, base::unserialize)
+#' serial_config(
+#'   c("torch_tensor", "ArrowTabular"),
+#'   list(torch::torch_serialize, arrow::write_to_raw),
+#'   list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+#' )
 #'
 #' @export
 #'
 serial_config <- function(class, sfunc, ufunc) {
 
   is.character(class) ||
-    stop("'class' must be a character string")
-  is.function(sfunc) && is.function(ufunc) ||
-    stop("both 'sfunc' and 'ufunc' must be functions")
+    stop("`class` must be a character string")
+  if (is.list(sfunc)) {
+    all(as.logical(lapply(sfunc, is.function))) && all(as.logical(lapply(ufunc, is.function)))
+  } else {
+    is.function(sfunc) && is.function(ufunc)
+  } || stop("both `sfunc` and `ufunc` must be functions")
+  length(class) == length(sfunc) && length(sfunc) == length(ufunc) ||
+    stop("`class`, `sfunc` and `ufunc` must be the same length")
 
   pairlist(class, sfunc, ufunc)
 

--- a/R/sakura.R
+++ b/R/sakura.R
@@ -50,6 +50,14 @@ serialize <- function(x, hook = NULL)
 #' cfg <- serial_config("torch_tensor", torch::torch_serialize, torch::torch_load)
 #' unserialize(serialize(x, cfg), cfg)
 #'
+#' cfg <- serial_config(
+#'   c("torch_tensor", "ArrowTabular"),
+#'   list(torch::torch_serialize, arrow::write_to_raw),
+#'   list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+#' )
+#' y <- list(torch::torch_rand(5L), runif(5L), arrow::as_arrow_table(iris))
+#' unserialize(serialize(y, cfg), cfg)
+#'
 #' @rdname serialize
 #' @export
 #'

--- a/man/serial_config.Rd
+++ b/man/serial_config.Rd
@@ -7,14 +7,15 @@
 serial_config(class, sfunc, ufunc)
 }
 \arguments{
-\item{class}{character string of the class of object custom serialization
-functions are applied to, e.g. 'ArrowTabular' or 'torch_tensor'.}
+\item{class}{a character string (or vector) of the class of object custom
+serialization functions are applied to, e.g. \code{'ArrowTabular'} or
+\code{c('torch_tensor', 'ArrowTabular')}.}
 
-\item{sfunc}{a function that accepts a reference object inheriting from
-\code{class} and returns a raw vector.}
+\item{sfunc}{a function (or list of functions) that accepts a reference
+object inheriting from \code{class} and returns a raw vector.}
 
-\item{ufunc}{a function that accepts a raw vector and returns a reference
-object.}
+\item{ufunc}{a function (or list of functions) that accepts a raw vector and
+returns a reference object.}
 }
 \value{
 A pairlist comprising the configuration. This may be provided to the
@@ -27,10 +28,11 @@ of R native serialization. This allows their use across different R sessions.
 }
 \examples{
 serial_config("test_class", base::serialize, base::unserialize)
+
 serial_config(
-  c("torch_tensor", "ArrowTabular"),
-  list(torch::torch_serialize, arrow::write_to_raw),
-  list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+  c("class_one", "class_two"),
+  list(base::serialize, base::serialize),
+  list(base::unserialize, base::unserialize)
 )
 
 }

--- a/man/serial_config.Rd
+++ b/man/serial_config.Rd
@@ -27,5 +27,10 @@ of R native serialization. This allows their use across different R sessions.
 }
 \examples{
 serial_config("test_class", base::serialize, base::unserialize)
+serial_config(
+  c("torch_tensor", "ArrowTabular"),
+  list(torch::torch_serialize, arrow::write_to_raw),
+  list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+)
 
 }

--- a/man/serialize.Rd
+++ b/man/serialize.Rd
@@ -41,5 +41,13 @@ unserialize(raw, cfg)
 x <- list(torch::torch_rand(5L), runif(5L))
 cfg <- serial_config("torch_tensor", torch::torch_serialize, torch::torch_load)
 unserialize(serialize(x, cfg), cfg)
+
+cfg <- serial_config(
+  c("torch_tensor", "ArrowTabular"),
+  list(torch::torch_serialize, arrow::write_to_raw),
+  list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+)
+y <- list(torch::torch_rand(5L), runif(5L), arrow::as_arrow_table(iris))
+unserialize(serialize(y, cfg), cfg)
 \dontshow{\}) # examplesIf}
 }

--- a/man/serialize.Rd
+++ b/man/serialize.Rd
@@ -41,7 +41,8 @@ unserialize(raw, cfg)
 x <- list(torch::torch_rand(5L), runif(5L))
 cfg <- serial_config("torch_tensor", torch::torch_serialize, torch::torch_load)
 unserialize(serialize(x, cfg), cfg)
-
+\dontshow{\}) # examplesIf}
+\dontshow{if (requireNamespace("arrow", quietly = TRUE) && requireNamespace("torch", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 cfg <- serial_config(
   c("torch_tensor", "ArrowTabular"),
   list(torch::torch_serialize, arrow::write_to_raw),

--- a/src/core.c
+++ b/src/core.c
@@ -52,15 +52,24 @@ static SEXP nano_serialize_hook(SEXP x, SEXP bundle_xptr) {
 
   sakura_serial_bundle * bundle = (sakura_serial_bundle *) R_ExternalPtrAddr(bundle_xptr);
   R_outpstream_t stream = bundle->stream;
-  const char *klass = bundle->klass;
+  SEXP klass = bundle->klass;
   SEXP hook_func = bundle->hook_func;
+  int len = (int) XLENGTH(klass), i = -1;
   void (*OutBytes)(R_outpstream_t, void *, int) = stream->OutBytes;
 
-  if (!Rf_inherits(x, klass))
-    return R_NilValue;
+  if (len > 1) {
+    i = 0;
+    do {
+      if (Rf_inherits(x, CHAR(STRING_ELT(klass, i))))
+        break;
+      i++;
+      if (i == len)
+        return R_NilValue;
+    } while (i < len);
+  }
 
   SEXP call;
-  PROTECT(call = Rf_lcons(hook_func, Rf_cons(x, R_NilValue)));
+  PROTECT(call = Rf_lcons(len < 0 ? hook_func : VECTOR_ELT(hook_func, i), Rf_cons(x, R_NilValue)));
   if (!R_ToplevelExec(nano_eval_safe, call) || TYPEOF(nano_eval_res) != RAWSXP) {
     // something went wrong
     UNPROTECT(1);
@@ -94,6 +103,7 @@ static SEXP nano_serialize_hook(SEXP x, SEXP bundle_xptr) {
 
   // write out binary serialization blob
   OutBytes(stream, RAW(nano_eval_res), (int) size);
+  OutBytes(stream, &i, sizeof(int));      // 4
 
   return R_BlankScalarString; // this will write the PERSISTXP again
 
@@ -117,11 +127,14 @@ static SEXP nano_unserialize_hook(SEXP x, SEXP bundle_xptr) {
   PROTECT(raw = Rf_allocVector(RAWSXP, size));
   InBytes(stream, RAW(raw), (int) size);
 
+  int i;
+  InBytes(stream, &i, 4);
+
   // read in 20 additional bytes and discard them
   char buf[20];
   InBytes(stream, buf, 20);
 
-  PROTECT(call = Rf_lcons(hook_func, Rf_cons(raw, R_NilValue)));
+  PROTECT(call = Rf_lcons(i < 0 ? hook_func : VECTOR_ELT(hook_func, i), Rf_cons(raw, R_NilValue)));
   out = Rf_eval(call, R_GlobalEnv);
 
   UNPROTECT(2);
@@ -132,7 +145,7 @@ static SEXP nano_unserialize_hook(SEXP x, SEXP bundle_xptr) {
 // C API functions -------------------------------------------------------------
 
 void sakura_serialize_init(SEXP bundle_xptr, R_outpstream_t stream, R_pstream_data_t data,
-                           const char *klass, SEXP hook_func, void (*outbytes)(R_outpstream_t, void *, int)) {
+                           SEXP klass, SEXP hook_func, void (*outbytes)(R_outpstream_t, void *, int)) {
 
   sakura_serial_bundle * bundle = (sakura_serial_bundle *) R_ExternalPtrAddr(bundle_xptr);
 
@@ -207,7 +220,7 @@ void sakura_serialize(nano_buf *buf, SEXP object, SEXP hook) {
       bundle,
       &output_stream,
       (R_pstream_data_t) buf,
-      CHAR(STRING_ELT(klass, 0)),
+      klass,
       hook_func,
       nano_write_bytes);
 

--- a/src/sakura.h
+++ b/src/sakura.h
@@ -23,7 +23,7 @@ typedef struct nano_buf_s {
 
 typedef struct sakura_serial_bundle_s {
   R_outpstream_t stream;
-  const char *klass;
+  SEXP klass;
   SEXP hook_func;
 } sakura_serial_bundle;
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -26,7 +26,7 @@ if (requireNamespace("torch", quietly = TRUE)) {
     ufunc = torch::torch_load
   )
   test_type("pairlist", cfg)
-  obj <- list(a = torch::torch_rand(1e3), b = new.env(), vector = runif(1000L))
+  obj <- list(a = torch::torch_rand(1e3L), b = new.env(), vector = runif(1000L))
   vec <- serialize(obj, cfg)
   test_type("raw", vec)
   test_true(all.equal(unserialize(vec, cfg), obj))
@@ -47,4 +47,23 @@ if (requireNamespace("arrow", quietly = TRUE)) {
   vec <- serialize(x, cfga)
   test_type("raw", vec)
   test_true(all.equal(unserialize(vec, cfga), x))
+}
+
+if (requireNamespace("torch", quietly = TRUE) && requireNamespace("arrow", quietly = TRUE)) {
+  cfgc <- serial_config(
+    c("torch_tensor", "ArrowTabular"),
+    list(torch::torch_serialize, arrow::write_to_raw),
+    list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
+  )
+  test_type("pairlist", cfgc)
+  test_type("raw", serialize(obj, cfga))
+  y <- list(
+    a = arrow::as_arrow_table(iris),
+    b = torch::torch_rand(1e3L),
+    c = new.env(),
+    runif(5L)
+  )
+  vec <- serialize(y, cfgc)
+  test_type("raw", vec)
+  test_true(all.equal(unserialize(vec, cfgc), y))
 }


### PR DESCRIPTION
Closes #11.

E.g.

```r
cfg <- serial_config(
  c("torch_tensor", "ArrowTabular"),
  list(torch::torch_serialize, arrow::write_to_raw),
  list(torch::torch_load, function(x) arrow::read_ipc_stream(x, as_data_frame = FALSE))
)
```

Follow up to #8. FYI @traversc.